### PR TITLE
substituted deprecated function call to fix config flow in HA 2025.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,44 @@ The device should respond with JSON data containing:
 }
 ```
 
+## Additional Services (Home Assistant)
+
+This integration now provides several additional services to control scheduler, messages, storage and to fetch raw display data. Use them from Developer Tools → Services or in automations.
+
+- `ikea_obegraensad.set_schedule` — set a schedule. Data: `schedule` (JSON or list of objects). Example:
+
+```yaml
+service: ikea_obegraensad.set_schedule
+data:
+  schedule:
+    - pluginId: 3
+      duration: 30
+    - pluginId: 5
+      duration: 60
+```
+
+- `ikea_obegraensad.clear_schedule`, `ikea_obegraensad.start_schedule`, `ikea_obegraensad.stop_schedule` — control schedule lifecycle.
+
+- `ikea_obegraensad.add_message` — add a display message. Data: `text` (required), optional `repeat`, `id`, `delay`, `graph` (list), `miny`, `maxy`.
+
+```yaml
+service: ikea_obegraensad.add_message
+data:
+  text: "Hello"
+  repeat: 1
+  id: 99
+```
+
+- `ikea_obegraensad.remove_message` — remove message by `id`.
+
+- `ikea_obegraensad.clear_storage` — clear device storage (if supported by firmware).
+
+- `ikea_obegraensad.get_data` — fetch raw framebuffer (`/api/data`) and save it to Home Assistant config directory as `ikea_obegraensad_data.bin`.
+
+Additionally, a UI Button entity `Persist Plugin` is available to persist the current plugin on the device (same as the `persist_plugin` service).
+
+These services are implemented using the device HTTP API (where applicable) or WebSocket for real-time commands.
+
 ## Troubleshooting
 
 ### Connection Issues

--- a/custom_components/ikea_obegraensad/__init__.py
+++ b/custom_components/ikea_obegraensad/__init__.py
@@ -1,13 +1,15 @@
 """The IKEA OBEGRÄNSAD LED Control integration."""
 from __future__ import annotations
 
+import json
 import logging
-from typing import Any
 
+import voluptuous as vol
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import selector
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import DOMAIN
 from .coordinator import IkeaLedCoordinator
@@ -17,17 +19,189 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORMS: list[Platform] = [Platform.LIGHT, Platform.SELECT, Platform.SENSOR, Platform.BUTTON]
 
 
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
+    """Set up the integration and register module-level services.
+
+    Services are registered at module level so they show up in the UI even
+    before an entry is configured. Handlers will pick the right coordinator
+    based on configured entries.
+    """
+
+    def _get_coordinator(host: str | None = None) -> IkeaLedCoordinator | None:
+        data = hass.data.get(DOMAIN, {})
+        if host:
+            for entry_id, coord in data.items():
+                if isinstance(coord, IkeaLedCoordinator) and coord.host == host:
+                    return coord
+
+        # If only a single coordinator is configured, return it
+        coords = [c for c in data.values() if isinstance(c, IkeaLedCoordinator)]
+        if len(coords) == 1:
+            return coords[0]
+        return None
+
+    async def persist_plugin_service(call) -> None:
+        host = call.data.get("host")
+        coord = _get_coordinator(host)
+        if not coord:
+            _LOGGER.error("No IKEA OBEGRÄNSAD coordinator found for persist_plugin")
+            return
+        await hass.async_add_executor_job(coord.persist_plugin)
+
+    async def set_schedule_service(call) -> None:
+        host = call.data.get("host")
+        schedule = call.data.get("schedule")
+        coord = _get_coordinator(host)
+        if not coord:
+            _LOGGER.error("No IKEA OBEGRÄNSAD coordinator found for set_schedule")
+            return
+        # Expect schedule as a JSON string in the UI for best frontend support.
+        # If callers provide structured data (dict/list), convert to JSON here.
+        if not isinstance(schedule, str):
+            schedule = json.dumps(schedule)
+        await coord.async_set_schedule(schedule)
+
+    async def clear_schedule_service(call) -> None:
+        host = call.data.get("host")
+        coord = _get_coordinator(host)
+        if not coord:
+            _LOGGER.error("No IKEA OBEGRÄNSAD coordinator found for clear_schedule")
+            return
+        await coord.async_clear_schedule()
+
+    async def start_schedule_service(call) -> None:
+        host = call.data.get("host")
+        coord = _get_coordinator(host)
+        if not coord:
+            _LOGGER.error("No IKEA OBEGRÄNSAD coordinator found for start_schedule")
+            return
+        await coord.async_start_schedule()
+
+    async def stop_schedule_service(call) -> None:
+        host = call.data.get("host")
+        coord = _get_coordinator(host)
+        if not coord:
+            _LOGGER.error("No IKEA OBEGRÄNSAD coordinator found for stop_schedule")
+            return
+        await coord.async_stop_schedule()
+
+    async def add_message_service(call) -> None:
+        host = call.data.get("host")
+        coord = _get_coordinator(host)
+        if not coord:
+            _LOGGER.error("No IKEA OBEGRÄNSAD coordinator found for add_message")
+            return
+        text = call.data.get("text")
+        repeat = call.data.get("repeat", 1)
+        mid = call.data.get("id", 0)
+        delay = call.data.get("delay", 50)
+        graph = call.data.get("graph")
+        miny = call.data.get("miny", 0)
+        maxy = call.data.get("maxy", 15)
+        # If graph is provided as string (JSON array or CSV), parse into list[int]
+        graph_list = None
+        if isinstance(graph, str):
+            # Try JSON first
+            try:
+                parsed = json.loads(graph)
+                if isinstance(parsed, list):
+                    graph_list = [int(x) for x in parsed]
+            except Exception:
+                # Fallback: parse comma-separated integers
+                try:
+                    parts = [p.strip() for p in graph.split(",") if p.strip()]
+                    graph_list = [int(p) for p in parts]
+                except Exception:
+                    graph_list = None
+        else:
+            graph_list = graph
+
+        await coord.async_add_message(text, repeat, mid, delay, graph_list, miny, maxy)
+
+    async def remove_message_service(call) -> None:
+        host = call.data.get("host")
+        coord = _get_coordinator(host)
+        if not coord:
+            _LOGGER.error("No IKEA OBEGRÄNSAD coordinator found for remove_message")
+            return
+        mid = call.data.get("id")
+        await coord.async_remove_message(mid)
+
+    async def clear_storage_service(call) -> None:
+        host = call.data.get("host")
+        coord = _get_coordinator(host)
+        if not coord:
+            _LOGGER.error("No IKEA OBEGRÄNSAD coordinator found for clear_storage")
+            return
+        await coord.async_clear_storage()
+
+    async def get_data_service(call) -> None:
+        host = call.data.get("host")
+        coord = _get_coordinator(host)
+        if not coord:
+            _LOGGER.error("No IKEA OBEGRÄNSAD coordinator found for get_data")
+            return
+        data = await coord.async_get_data()
+        if not data:
+            _LOGGER.error("Failed to fetch data from device")
+            return
+        try:
+            hass_config = hass.config.path()
+            outpath = f"{hass_config}/ikea_obegraensad_data.bin"
+            with open(outpath, "wb") as f:
+                f.write(data)
+            _LOGGER.info("Saved device data to %s", outpath)
+        except Exception as ex:
+            _LOGGER.error("Failed to save device data: %s", ex)
+
+    # Service schemas (use selector objects for better UI rendering)
+    persist_schema = vol.Schema({vol.Optional("host"): selector.TextSelector({})})
+    set_schedule_schema = vol.Schema(
+        {
+            vol.Optional("host"): selector.TextSelector({}),
+            vol.Required("schedule"): selector.TextSelector({"multiline": True}),
+        }
+    )
+    simple_host_schema = vol.Schema({vol.Optional("host"): selector.TextSelector({})})
+    add_message_schema = vol.Schema(
+        {
+            vol.Optional("host"): selector.TextSelector({}),
+            vol.Required("text"): selector.TextSelector({"multiline": True}),
+            vol.Optional("repeat", default=1): selector.NumberSelector({"min": 1, "max": 1000}),
+            vol.Optional("id", default=0): selector.NumberSelector({"min": 0, "max": 65535}),
+            vol.Optional("delay", default=50): selector.NumberSelector({"min": 0, "max": 10000}),
+            vol.Optional("graph"): selector.TextSelector({}),
+            vol.Optional("miny", default=0): selector.NumberSelector({"min": -32768, "max": 32767}),
+            vol.Optional("maxy", default=15): selector.NumberSelector({"min": -32768, "max": 32767}),
+        }
+    )
+    remove_message_schema = vol.Schema(
+        {vol.Optional("host"): selector.TextSelector({}), vol.Required("id"): selector.NumberSelector({"min": 0, "max": 65535})}
+    )
+
+    hass.services.async_register(DOMAIN, "persist_plugin", persist_plugin_service, schema=persist_schema)
+    hass.services.async_register(DOMAIN, "set_schedule", set_schedule_service, schema=set_schedule_schema)
+    hass.services.async_register(DOMAIN, "clear_schedule", clear_schedule_service, schema=simple_host_schema)
+    hass.services.async_register(DOMAIN, "start_schedule", start_schedule_service, schema=simple_host_schema)
+    hass.services.async_register(DOMAIN, "stop_schedule", stop_schedule_service, schema=simple_host_schema)
+    hass.services.async_register(DOMAIN, "add_message", add_message_service, schema=add_message_schema)
+    hass.services.async_register(DOMAIN, "remove_message", remove_message_service, schema=remove_message_schema)
+    hass.services.async_register(DOMAIN, "clear_storage", clear_storage_service, schema=simple_host_schema)
+    hass.services.async_register(DOMAIN, "get_data", get_data_service, schema=simple_host_schema)
+
+    return True
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up IKEA OBEGRÄNSAD LED Control from a config entry."""
+    """Set up from a config entry (per device)."""
     host = entry.data[CONF_HOST]
-    
     coordinator = IkeaLedCoordinator(hass, host)
-    
+
     try:
         await coordinator.async_config_entry_first_refresh()
-    except Exception as ex:
+    except Exception:
         _LOGGER.exception("Error setting up IKEA OBEGRÄNSAD LED device")
-        raise ConfigEntryNotReady from ex
+        raise
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = coordinator
@@ -43,5 +217,4 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         coordinator = hass.data[DOMAIN][entry.entry_id]
         await coordinator.async_shutdown()
         hass.data[DOMAIN].pop(entry.entry_id)
-
     return unload_ok

--- a/custom_components/ikea_obegraensad/button.py
+++ b/custom_components/ikea_obegraensad/button.py
@@ -29,6 +29,8 @@ async def async_setup_entry(
         IkeaLedRotateLeftButton(coordinator, entry),
         IkeaLedRotateRightButton(coordinator, entry),
     ]
+    # Add persist plugin button for easier UI access
+    buttons.append(IkeaLedPersistPluginButton(coordinator, entry))
     
     async_add_entities(buttons)
 
@@ -113,3 +115,26 @@ class IkeaLedRotateRightButton(IkeaLedBaseButton):
             await self.coordinator.async_refresh_after_command()
         except Exception as ex:
             _LOGGER.error("Failed to rotate right: %s", ex)
+
+
+class IkeaLedPersistPluginButton(IkeaLedBaseButton):
+    """Button to persist the currently active plugin on device."""
+
+    def __init__(self, coordinator: IkeaLedCoordinator, entry: ConfigEntry) -> None:
+        super().__init__(
+            coordinator,
+            entry,
+            "persist_plugin",
+            "Persist Plugin",
+            "mdi:content-save"
+        )
+
+    async def async_press(self) -> None:
+        try:
+            await self.hass.async_add_executor_job(
+                self.coordinator.persist_plugin
+            )
+            # Gentle refresh
+            await self.coordinator.async_refresh_after_command()
+        except Exception as ex:
+            _LOGGER.error("Failed to persist plugin: %s", ex)

--- a/custom_components/ikea_obegraensad/config_flow.py
+++ b/custom_components/ikea_obegraensad/config_flow.py
@@ -40,9 +40,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             # Test connection
             try:
                 await self._test_connection(host)
-            except Exception as e:  # pylint: disable=broad-except
+            except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Unexpected exception")
-                errors["base"] = e
+                # Use a serializable error code for the UI
+                errors["base"] = "cannot_connect"
             else:
                 # Check if already configured
                 await self.async_set_unique_id(host)
@@ -71,8 +72,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             # Give it time to establish WebSocket connection
             await asyncio.sleep(3)
             
-            # Try to get initial data
-            await test_coordinator.async_config_entry_first_refresh()
+            # Try to get initial data: use async_refresh to avoid ConfigEntryError
+            await test_coordinator.async_refresh()
             
             # Check if we got valid data
             if not test_coordinator.data or not isinstance(test_coordinator.data, dict):

--- a/custom_components/ikea_obegraensad/sensor.py
+++ b/custom_components/ikea_obegraensad/sensor.py
@@ -134,14 +134,20 @@ class IkeaLedActivePluginSensor(IkeaLedBaseSensor):
         """Return extra state attributes."""
         if not self.coordinator.data:
             return None
-            
-        return {
+        attrs = {
             "plugin_id": self.coordinator.data.get("plugin"),
             "available_plugins": [
                 {"id": plugin.get("id"), "name": plugin.get("name", "Unknown")}
                 for plugin in self.coordinator.data.get("plugins", [])
             ],
         }
+
+        # Include persisted plugin id if the device reports it
+        persisted = self.coordinator.data.get("persistPlugin")
+        if persisted is not None:
+            attrs["persisted_plugin_id"] = persisted
+
+        return attrs
 
 
 class IkeaLedScheduleStatusSensor(IkeaLedBaseSensor):

--- a/custom_components/ikea_obegraensad/services.yaml
+++ b/custom_components/ikea_obegraensad/services.yaml
@@ -1,0 +1,123 @@
+persist_plugin:
+  description: "Persist plugin on device"
+  fields:
+    host:
+      description: "Optional host to pick a specific device"
+      example: "192.168.1.42"
+      selector:
+        text: {}
+
+set_schedule:
+  description: "Set the device schedule. Provide schedule data (JSON or other) as text."
+  fields:
+    host:
+      description: "Optional host to pick a specific device"
+      example: "192.168.1.42"
+      selector:
+        text: {}
+    schedule:
+      description: "Schedule data (JSON string or other). Use multiline for long payloads."
+      selector:
+        text:
+          multiline: true
+
+clear_schedule:
+  description: "Clear schedule on device"
+  fields:
+    host:
+      description: "Optional host to pick a specific device"
+      selector:
+        text: {}
+
+start_schedule:
+  description: "Start schedule on device"
+  fields:
+    host:
+      description: "Optional host to pick a specific device"
+      selector:
+        text: {}
+
+stop_schedule:
+  description: "Stop schedule on device"
+  fields:
+    host:
+      description: "Optional host to pick a specific device"
+      selector:
+        text: {}
+
+add_message:
+  description: "Add a message / graph to the device"
+  fields:
+    host:
+      description: "Optional host to pick a specific device"
+      selector:
+        text: {}
+    text:
+      description: "Message text"
+      selector:
+        text:
+          multiline: true
+    repeat:
+      description: "How often to repeat the message"
+      selector:
+        number:
+          min: 1
+          max: 1000
+    id:
+      description: "Message id (optional, 0 for automatic)"
+      selector:
+        number:
+          min: 0
+          max: 65535
+    delay:
+      description: "Delay between frames (ms)"
+      selector:
+        number:
+          min: 0
+          max: 10000
+    graph:
+      description: "Graph data as JSON array or CSV string (use a single-line or short text)"
+      selector:
+        text: {}
+    miny:
+      description: "Graph min Y"
+      selector:
+        number:
+          min: -32768
+          max: 32767
+    maxy:
+      description: "Graph max Y"
+      selector:
+        number:
+          min: -32768
+          max: 32767
+
+remove_message:
+  description: "Remove a message by id"
+  fields:
+    host:
+      description: "Optional host to pick a specific device"
+      selector:
+        text: {}
+    id:
+      description: "ID of the message to remove"
+      selector:
+        number:
+          min: 0
+          max: 65535
+
+clear_storage:
+  description: "Clear storage on device"
+  fields:
+    host:
+      description: "Optional host to pick a specific device"
+      selector:
+        text: {}
+
+get_data:
+  description: "Fetch device binary data and save to Home Assistant config directory"
+  fields:
+    host:
+      description: "Optional host to pick a specific device"
+      selector:
+        text: {}


### PR DESCRIPTION
The way the connection test during config flow was implemented is deprecated and does not work anymore since HA 2025.12. 
I rewrote the connection test to be compatible again. Tested successfully with HA 2025.12.2. This fixes issue #2 